### PR TITLE
Add option to not focus when opening a new tab

### DIFF
--- a/ext/background.js
+++ b/ext/background.js
@@ -78,7 +78,7 @@ var bridge = {
 		browser.tabs.move(tab.id, { index });
 	},
 
-    openTab: function(href, focus) {
+	openTab: function(href, focus) {
 		browser.tabs.create({
 		    url: href,
 		    active: focus

--- a/ext/background.js
+++ b/ext/background.js
@@ -80,7 +80,8 @@ var bridge = {
 
 	openTab: function(href) {
 		browser.tabs.create({
-			url: href
+		    url: href,
+		    active: false
 		});
 	},
 };

--- a/ext/background.js
+++ b/ext/background.js
@@ -78,10 +78,10 @@ var bridge = {
 		browser.tabs.move(tab.id, { index });
 	},
 
-	openTab: function(href) {
+    openTab: function(href, focus) {
 		browser.tabs.create({
 		    url: href,
-		    active: false
+		    active: focus
 		});
 	},
 };

--- a/ext/content.js
+++ b/ext/content.js
@@ -373,7 +373,7 @@ var blobList = {
 
 		blobList.hideBlobs();
 		if (blob.linkElem.tagName == "A" && blob.linkElem.href) {
-		    bridge.openTab(blob.linkElem.href, conf.focus_new_tab.trim().length != 0);
+			bridge.openTab(blob.linkElem.href, conf.focus_new_tab.trim().length != 0);
 		} else {
 			blob.linkElem.click();
 			blob.linkElem.focus();

--- a/ext/content.js
+++ b/ext/content.js
@@ -20,8 +20,8 @@ var bridge = {
 		callBridge("moveTabRight");
 	},
 
-	openTab: function(href) {
-		callBridge("openTab", href);
+	openTab: function(href, focus) {
+		callBridge("openTab", href, focus);
 	},
 
 	setClipboard: function(txt) {
@@ -57,6 +57,7 @@ var defaultConf = {
 	scroll_friction: 0.8,
 	chars: ";alskdjfir",
 	timer: 0,
+	focus_new_tab: "yes",
 	input_whitelist: ["checkbox", "radio", "hidden", "submit", "reset", "button", "file", "image"],
 	location_change_check_timeout: 2000,
 	yt_fix_space: true,
@@ -372,7 +373,7 @@ var blobList = {
 
 		blobList.hideBlobs();
 		if (blob.linkElem.tagName == "A" && blob.linkElem.href) {
-			bridge.openTab(blob.linkElem.href);
+		    bridge.openTab(blob.linkElem.href, conf.focus_new_tab.trim().length != 0);
 		} else {
 			blob.linkElem.click();
 			blob.linkElem.focus();

--- a/settings/options.html
+++ b/settings/options.html
@@ -66,6 +66,11 @@ select {
 				<input class="current">
 			</label>
 
+			<label class="option" name="conf.focus_new_tab">
+				Focus to the new tab (remove all text to not focus)
+				<input class="current">
+			</label>
+
 			<label class="option big" name="conf.blacklist">
 				Blacklisted URLs
 				<textarea

--- a/settings/options.js
+++ b/settings/options.js
@@ -4,7 +4,8 @@ var presets = {
 		conf: {
 			chars: ";alskdjfir",
 			blacklist: "",
-			timer: 0
+			timer: 0,
+			focus_new_tab: "yes",
 		},
 		keys: {
 			scroll_up: "k",
@@ -32,7 +33,8 @@ var presets = {
 		conf: {
 			chars: "øalskdjfir",
 			blacklist: "",
-			timer: 0
+			timer: 0,
+			focus_new_tab: "yes",
 		},
 		keys: {
 			scroll_up: "k",
@@ -60,7 +62,8 @@ var presets = {
 		conf: {
 			chars: "mqlskdjfir",
 			blacklist: "",
-			timer: 0
+			timer: 0,
+			focus_new_tab: "yes",
 		},
 		keys: {
 			scroll_up: "k",
@@ -88,7 +91,8 @@ var presets = {
 		conf: {
 			chars: "sanotehucp",
 			blacklist: "",
-			timer: 0
+			timer: 0,
+		        focus_new_tab: "yes",
 		},
 		keys: {
 			scroll_up: "t",
@@ -116,7 +120,8 @@ var presets = {
 		conf: {
 			chars: "oairesntup",
 			blacklist: "",
-			timer: 0
+			timer: 0,
+			focus_new_tab: "yes",
 		},
 		keys: {
 			scroll_up: "e",
@@ -144,7 +149,8 @@ var presets = {
 		conf: {
 			chars: "123456789",
 			blacklist: "",
-			timer: 0
+			timer: 0,
+			focus_new_tab: "yes",
 		},
 		keys: {
 			scroll_up: " ",


### PR DESCRIPTION
As the title says, this pull request add an option to not focus on when opening a new tab.

I am not a html/js developer, so it's kinda raw, particularly for the settings menu, when I couldn't make a checkbox to work with the rest of the extension, so I made a textarea that is equivalent to 'unchecked' if empty.

It could also have been done differently by adding another keyboard combination.

Even so, I wanted to make a pull request, in case the maintainer or other people wants to build on this.
